### PR TITLE
ECSクラスターの作成

### DIFF
--- a/oreilly/modules/ecs/cluster.tf
+++ b/oreilly/modules/ecs/cluster.tf
@@ -1,0 +1,26 @@
+locals {
+  ecs_cluster_tags = merge(
+    var.cluster_additional_tags,
+    {
+        ServiceName = var.service_name
+        Env = var.env
+    }
+  )
+}
+
+resource "aws_ecs_cluster" "ecs_cluster" {
+  name = "${var.service_name}-${var.env}-cluster"
+  setting {
+    name = "containerInsights"
+    value = "enabled"
+  }
+  tags = local.ecs_cluster_tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "cluster_capacity_providers" {
+  cluster_name = aws_ecs_cluster.ecs_cluster.name
+
+  capacity_providers = [
+    "FARGATE"
+  ]
+}

--- a/oreilly/modules/ecs/outputs.tf
+++ b/oreilly/modules/ecs/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_name" {
+  description = "作成されたECSクラスター名"
+  value       = aws_ecs_cluster.ecs_cluster.name
+}
+
+output "cluster_arn" {
+  description = "作成されたECSクラスターARN"
+  value       = aws_ecs_cluster.ecs_cluster.arn
+}

--- a/oreilly/modules/ecs/variables.tf
+++ b/oreilly/modules/ecs/variables.tf
@@ -1,0 +1,20 @@
+variable "service_name" {
+  description = "VPCを利用するサービス名"
+  type = string
+}
+
+variable "env" {
+  description = "環境識別子(dev, stg, prod)"
+  type = string
+}
+
+variable "cluster_additional_tags" {
+  description = "ECSクラスターに付与したい追加タグ"
+  type = map(string)
+  default = {}
+  validation {
+    condition = length(setintersection(keys(var.cluster_additional_tags),
+    ["ServiceName", "Env"])) == 0
+    error_message = "Key names, ServiceName and Env is reserved. Not allowed to use them."
+  }
+}

--- a/oreilly/outputs.tf
+++ b/oreilly/outputs.tf
@@ -5,3 +5,21 @@ output "vpc_id" {
 output "vpc_name" {
   value = module.vpc.vpc_name
 }
+
+output "ecs_cluster_name" {
+  value = module.ecs_cluster.cluster_name
+}
+
+output "ecs_cluster_arn" {
+  value = module.ecs_cluster.cluster_arn
+}
+
+output "cluster_name" {
+    description = "作成されたクラスターの名前"
+    value = module.ecs_cluster.cluster_name
+}
+
+output "cluster_arn" {
+    description = "作成されたクラスターのARN"
+    value = module.ecs_cluster.cluster_arn
+}

--- a/oreilly/resources.tf
+++ b/oreilly/resources.tf
@@ -12,3 +12,9 @@ module "vpc" {
     Usage = "sample vpc explanation"
   }
 }
+
+module "ecs_cluster" {
+  source = "./modules/ecs"
+  service_name = "sample"
+  env = terraform.workspace
+}


### PR DESCRIPTION
# 12章 クラスターの作成
## 記載ミス
参照しているリソース名が実際の宣言名とずれていたために、`terraform plan`でエラーが起きていた。
